### PR TITLE
增加了对nginx-http-concat的支持

### DIFF
--- a/command.js
+++ b/command.js
@@ -11,6 +11,7 @@ program
     .option('-o, --port <path>', 'http portal, default 80')
     .option('-s, --ports <path>', 'https portal, default 443')
     .option('-p, --path <path>', 'middle path,default /m/app/src', '/m/app/src')
+    .option('-f, --foreign <path>', 'public dependencies path')
     .parse(process.argv);
 
 
@@ -25,19 +26,57 @@ var options = {
 options.agent = new httpsCreator.Agent(options);
 httpsCreator.createServer(options, function (request, response) {
     request.url = request.url.replace(program.path, '');
+    var dotUrls = [];
     request.addListener('end', function () {
-        fileServer.serve(request, response, function (e, res) {
-            e && console.log(e);
-        });
+        var fileContents = "";
+        if (request.url.indexOf("??") != -1) {
+            var rUrls = request.url.match(/^([^\?]*)\?{2}([^\?]*)\??.*$/);
+            dotUrls = rUrls[2].split(",");
+            dotUrls = dotUrls.map(function(current) {
+                return program.foreign + current;
+            });
+            try {
+                dotUrls.forEach(function(current) {
+                    fileContents += fs.readFileSync(current, 'utf-8');
+                });
+            }catch(e) {
+                console.log(e);
+            }
+        }else {
+            var fUrl = program.dir +request.url;
+            fileContents = fs.readFileSync(fUrl.match(/^([^\?]*)\??.*$/)[1], 'utf-8');
+        }
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.write(fileContents);
+        response.end();
     }).resume();
 }).listen(parseInt(program.ports ? program.ports : 443));
 
 httpCreator.createServer(function (request, response) {
     request.url = request.url.replace(program.path, '');
+    var dotUrls = [];
     request.addListener('end', function () {
-        fileServer.serve(request, response, function (e, res) {
-            e && console.log(e);
-        });
+        var fileContents = "";
+        if (request.url.indexOf("??") != -1) {
+            var rUrls = request.url.match(/^([^\?]*)\?{2}([^\?]*)\??.*$/);
+            dotUrls = rUrls[2].split(",");
+            dotUrls = dotUrls.map(function(current) {
+                return program.foreign + current;
+            });
+            try {
+                dotUrls.forEach(function(current) {
+                    fileContents += fs.readFileSync(current, 'utf-8');
+                });
+            }catch(e) {
+                console.log(e);
+            }
+        }else {
+            var fUrl = program.dir +request.url;
+            fileContents = fs.readFileSync(fUrl.match(/^([^\?]*)\??.*$/)[1], 'utf-8');
+        }
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.write(fileContents);
+        response.end();
     }).resume();
 }).listen(parseInt(program.port ? program.port : 80));
 

--- a/command.js
+++ b/command.js
@@ -24,6 +24,7 @@ var options = {
     cert: fs.readFileSync(path.join(__dirname, 'cacert.pem'))
 };
 options.agent = new httpsCreator.Agent(options);
+
 httpsCreator.createServer(options, function (request, response) {
     request.url = request.url.replace(program.path, '');
     var dotUrls = [];


### PR DESCRIPTION
1.增加了对nginx-http-concat的支持
2.增加了公共依赖库代理路径 -f 

使用方法:

node ./command.js -d "/Users/zhangmike/WebstormProjects/gomeplus/h5/dist" -p "/m/h5/dist" -f "/Users/zhangmike/WebstormProjects/gomeplus/public/dist/js/"
